### PR TITLE
PR for Refactor shutdown sequence to use plugin.stop

### DIFF
--- a/spec/inputs/xmpp_spec.rb
+++ b/spec/inputs/xmpp_spec.rb
@@ -1,1 +1,74 @@
+# encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
+require 'logstash/inputs/xmpp'
+require 'support/xmpp4r_mocks.rb'
+
+describe LogStash::Inputs::Xmpp do
+  let(:rooms) { ['logstash', 'kibana'] }
+  let(:config) do
+    {
+      'user' => 'foo@domain.org/chat',
+      'password' => 'bAr',
+      'rooms' => rooms
+    }
+  end
+
+  before do
+    allow(Jabber::Client).to receive(:new) do |jid|
+      Jabber::ClientMock.new(jid)
+    end
+
+    allow(Jabber::MUC::SimpleMUCClient).to receive(:new) do |client|
+      Jabber::MucClientMock.new(client)
+    end
+  end
+
+  context 'when running' do
+    let(:queue) { [] }
+    let(:msg)   { 'Hello Logstash'}
+    let(:inject_block) do
+      -> { subject.client.inject_message(Jabber::MessageMock.new(msg)) }
+    end
+
+    subject { LogStash::Inputs::Xmpp.new(config) }
+
+    before do
+      subject.register
+      plugin_thread = Thread.new(subject, queue) { |subj, que| subj.run(que) }
+      sleep 0.01 until plugin_thread.status == 'sleep'
+      inject_block.call
+      subject.stop
+    end
+
+    context "when using Client" do
+      it 'pushes normal events into a queue' do
+        event = queue.first
+        expect(event['message']).to eq(msg)
+        expect(event['from']).to eq('bar@domain.org/chat')
+      end
+    end
+
+    context "when using Rooms" do
+      let(:inject_block) do
+        -> do
+          subject.muc_clients.each do |muc|
+            muc.inject_message('now', 'bar', 'Hello Foo')
+          end
+        end
+      end
+
+      it 'pushes room events into a queue' do
+        rooms.each do |room|
+          event = queue.shift
+          expect(event['message']).to eq('Hello Foo')
+          expect(event['from']).to eq('bar')
+          expect(event['room']).to eq(room)
+        end
+      end
+    end
+  end
+
+  context 'when shutting down' do
+    it_behaves_like "an interruptible input plugin"
+  end
+end

--- a/spec/support/xmpp4r_mocks.rb
+++ b/spec/support/xmpp4r_mocks.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+module Jabber
+  class ClientMock
+    def initialize(jid)
+      @jid = jid
+      @message_block = ->(msg) { puts "!ERROR! ----> Should not see #{msg}"}
+    end
+    def connect(*) true; end
+    def auth(*) true; end
+    def send(*) true; end
+    def close(*) true; end
+    def add_presence_callback(*) true; end
+    def add_message_callback(*args, &block)
+      @message_block = block
+    end
+    def inject_message(msg)
+      @message_block.call(msg)
+    end
+  end
+
+  class MucClientMock
+    def initialize(client)
+      @message_block = ->(time, from, body) { puts "!!!!! ----> Should not see #{time}, #{from}, #{body}"}
+    end
+    def join(rm)
+    end
+    def on_message(&block)
+      @message_block = block
+    end
+    def inject_message(time, from, body)
+      @message_block.call(time, from, body)
+    end
+  end
+
+  class MessageMock
+    From = Struct.new(:node, :domain, :resource)
+    attr_reader :body, :from
+    def initialize(str)
+      @body = str
+      @from = From.new('bar','domain.org','chat')
+    end
+  end
+end


### PR DESCRIPTION
Shutdown semantics: Add stop method and shared_example
Add general tests (none before)
slight refactor
tests pass

Notes for Reviewers:
- This is a mixed PR, it contains code changes for the fix and general refactoring, because this plugin is very distant from core, the codebase has changed little since 2012 and there were no tests.
- The `require`s are not lazy loaded.
- Following our change in understanding about ivars and concurrency, I moved the ivar creation into the `initialize` method.
- I feared that when multiple rooms were specified, all but the last MUC client might be GC'd so I stored them in an array.
- I made the client and muc_clients available as attr readers so the tests could mimic the block call action when receiving messages.
- The tests use Mock classes that provide the same API as the Jabber Client and MUCSimpleClient.  Normally a test purist would say this is wrong because the API could change etc.  I considered this and figured that as the xmpp4r gem development has essentially stopped the risk was v low.
- The Mock classes are inline and not in a separate file so others can read them easily. I suspect, beyond bug fixes in this PR, this plugin will probably not see any more changes for some time.

Closes #3 
