### PR TITLE
Remove comment causing docgen issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.2
+  - Docs: Fix doc generation issue by removing extraneous comment
+
 ## 3.1.1
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/inputs/xmpp.rb
+++ b/lib/logstash/inputs/xmpp.rb
@@ -3,7 +3,6 @@ require "logstash/inputs/base"
 require "logstash/namespace"
 
 require 'xmpp4r' # xmpp4r gem
-# load the MUC Client anyway, its mocked in testing
 require 'xmpp4r/muc/helper/simplemucclient'
 
 # This input allows you to receive events over XMPP/Jabber.

--- a/logstash-input-xmpp.gemspec
+++ b/logstash-input-xmpp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-xmpp'
-  s.version         = '3.1.1'
+  s.version         = '3.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This input allows you to receive events over XMPP/Jabber."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Removes comment in order to fix the docgen issue described in elastic/logstash#6692.

@ph This topic does have a description. I think the docgen issue is being caused by the comment, so I've removed the comment. Let me know if this looks Ok, and I'll change the checklist in 6692.
